### PR TITLE
Make separator configurable

### DIFF
--- a/attributor-flatpack.gemspec
+++ b/attributor-flatpack.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'guard-rubocop'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug'
-  spec.add_development_dependency 'codeclimate-test-reporter'
+  spec.add_development_dependency 'simplecov'
 end

--- a/lib/attributor/flatpack/config.rb
+++ b/lib/attributor/flatpack/config.rb
@@ -1,10 +1,21 @@
 module Attributor
   module Flatpack
     class Config < Attributor::Hash
+      DEFAULT_SEPARATOR = '_'
       @key_type = Symbol
+
+      class << self
+        def separator(sep=nil)
+          return @separator unless sep
+          @separator = sep
+        end
+      end      
 
       def self.inherited(klass)
         super
+        klass.instance_eval do
+          @separator = Attributor::Flatpack::Config::DEFAULT_SEPARATOR
+        end
         klass.options[:dsl_compiler] = ConfigDSLCompiler
       end
 
@@ -98,7 +109,7 @@ module Attributor
       end
 
       def subselect(prefix)
-        prefix_match = /^#{prefix.to_s}_?(.*)/i
+        prefix_match = /^#{prefix.to_s}#{self.class.separator}?(.*)/i
 
         selected = @raw.collect do |(k, v)|
           if (match = prefix_match.match(k))

--- a/spec/attributor/flatpack/config_spec.rb
+++ b/spec/attributor/flatpack/config_spec.rb
@@ -55,6 +55,33 @@ describe Attributor::Flatpack::Config do
     end
   end
 
+  context 'unpacking names using a custom separator' do
+    let(:type) do
+      Class.new(Attributor::Flatpack::Config) do
+        separator '.'
+        keys do
+          key :foo do
+            key :bar, String
+          end
+          key :widget_factory, String
+        end
+      end
+    end
+
+    let(:data) do
+      {
+        'FOO.BAR' => 'Bar of Foos',
+        'WIDGET_FACTORY' => 'Factory of Widgets'
+      }
+    end
+    it 'unpacks names' do
+      expect(config.foo.bar).to eq 'Bar of Foos'
+    end
+    it 'still supports packed names' do
+      expect(config.widget_factory).to eq 'Factory of Widgets'
+    end
+  end
+  
   context 'merging names' do
     let(:data) do
       {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
+require 'simplecov'
+SimpleCov.start
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'attributor/flatpack'


### PR DESCRIPTION
    * a `separator` DSL can be used on a per config basis
    * or the default can be changed by redefining `Attributor::Flatpack::Config.DEFAULT_SEPARATOR`